### PR TITLE
added extra spacing because types are needed for orogen parsing

### DIFF
--- a/src/sbpl/SbplSplineMotionPrimitives.hpp
+++ b/src/sbpl/SbplSplineMotionPrimitives.hpp
@@ -38,7 +38,7 @@ struct SplinePrimitive
 class SbplSplineMotionPrimitives
 {
 private:
-    std::vector<std::vector<SplinePrimitive>> primitivesByAngle; //primitives by startAngle by id
+    std::vector< std::vector<SplinePrimitive> > primitivesByAngle; //primitives by startAngle by id
     SplinePrimitivesConfig config;
     double radPerDiscreteAngle;
   


### PR DESCRIPTION
because orogen does not support cpp11 stuff like <<>> generics without extra spaces, I've put some spaces there